### PR TITLE
Add initial support for custom input renderer

### DIFF
--- a/demo/src/components/App/App.js
+++ b/demo/src/components/App/App.js
@@ -10,6 +10,7 @@ import Example4 from 'Example4/Example4';
 import Example5 from 'Example5/Example5';
 import Example6 from 'Example6/Example6';
 import Example7 from 'Example7/Example7';
+import Example8 from 'Example8/Example8';
 
 export default class App extends Component {
   render() {
@@ -47,6 +48,9 @@ export default class App extends Component {
           </div>
           <div className={styles.exampleContainer}>
             <Example7 />
+          </div>
+          <div className={styles.exampleContainer}>
+            <Example8 />
           </div>
         </div>
         <ForkMeOnGitHub user="moroshko" repo="react-autowhatever" />

--- a/demo/src/components/App/components/Example8/Example8.js
+++ b/demo/src/components/App/components/Example8/Example8.js
@@ -1,0 +1,56 @@
+import theme from '../theme.less';
+
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { updateInputValue } from 'actions/app';
+import Autowhatever from 'Autowhatever';
+import SourceCodeLink from 'SourceCodeLink/SourceCodeLink';
+
+const exampleId = '8';
+const file = `demo/src/components/App/components/Example${exampleId}/Example${exampleId}.js`;
+
+function mapStateToProps(state) {
+  return {
+    value: state[exampleId].value
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onChange: event => dispatch(updateInputValue(exampleId, event.target.value))
+  };
+}
+
+class Example extends Component {
+  static propTypes = {
+    value: PropTypes.string.isRequired,
+    onChange: PropTypes.func.isRequired
+  };
+
+  renderTextArea(inputProps) {
+
+    console.log('input props', inputProps);
+
+    return (
+      <textarea {...inputProps} rows={3} />
+    );
+  }
+
+  render() {
+    const { value, onChange } = this.props;
+    const inputProps = { value, onChange };
+
+    return (
+      <div>
+        <Autowhatever id={exampleId}
+                      items={[]}
+                      inputProps={inputProps}
+                      renderInput={this.renderTextArea}
+                      theme={theme} />
+        <SourceCodeLink file={file} />
+      </div>
+    );
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Example);

--- a/demo/src/components/reducers/app.js
+++ b/demo/src/components/reducers/app.js
@@ -30,6 +30,9 @@ const initialState = {
     value: 'Multi section - Up/Down/Enter',
     focusedSectionIndex: null,
     focusedItemIndex: null
+  },
+  8: {
+    value: 'Text area'
   }
 };
 

--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -14,6 +14,7 @@ export default class Autowhatever extends Component {
     renderSectionTitle: PropTypes.func,    // This function gets a section and renders its title.
     getSectionItems: PropTypes.func,       // This function gets a section and returns its items, which will be passed into `renderItem` for rendering.
     inputProps: PropTypes.object,          // Arbitrary input props
+    renderInput: PropTypes.func,           // This function gets inputProps and returns react element for input
     itemProps: PropTypes.oneOfType([       // Arbitrary item props
       PropTypes.object,
       PropTypes.func
@@ -178,6 +179,16 @@ export default class Autowhatever extends Component {
     );
   }
 
+  renderInput(inputProps) {
+    if (typeof this.props.renderInput === 'function') {
+      return this.props.renderInput(inputProps);
+    }
+
+    return (
+      <input {...inputProps} />
+    );
+  }
+
   onKeyDown(event) {
     const { inputProps, focusedSectionIndex, focusedItemIndex } = this.props;
     const { onKeyDown: onKeyDownFn } = inputProps; // Babel is throwing:
@@ -227,10 +238,11 @@ export default class Autowhatever extends Component {
       ...this.props.inputProps,
       onKeyDown: this.props.inputProps.onKeyDown && this.onKeyDown
     };
+    const input = this.renderInput(inputProps);
 
     return (
       <div {...theme('container', 'container', isOpen && 'containerOpen')}>
-        <input {...inputProps} />
+        {input}
         {renderedItems}
       </div>
     );


### PR DESCRIPTION
Adds `renderInput` property to `<Autowhatever />`. It is a function that receives inputProps as an argument and returns React element to be used as input field.

This comes out of the need to use `<textarea>` as an input. With this change, textarea can be rendered with autowhatever like this:

```jsx
<Autowhatever
  inputProps={inputProps}
  renderInput={(inputProps) => (<textarea {...inputProps} />)}
  />
```

Without providing `renderInput` property everything works as it did before.

Please let me know if this is something that would be acceptable in autowhatever and i'll finalize the change (figure out theming, add documentation etc).

Related change for autosuggest component: https://github.com/priithaamer/react-autosuggest/commit/bdb7769f42007e59e358ba604d3a255602744bcb