### PR TITLE
Add code to scroll suggestion container to show focused item.

### DIFF
--- a/demo/src/components/App/App.js
+++ b/demo/src/components/App/App.js
@@ -9,6 +9,7 @@ import Example3 from 'Example3/Example3';
 import Example4 from 'Example4/Example4';
 import Example5 from 'Example5/Example5';
 import Example6 from 'Example6/Example6';
+import Example6s from 'Example6s/Example6s';
 import Example7 from 'Example7/Example7';
 
 export default class App extends Component {
@@ -44,6 +45,9 @@ export default class App extends Component {
           </div>
           <div className={styles.exampleContainer}>
             <Example6 />
+          </div>
+          <div className={styles.exampleContainer}>
+            <Example6s />
           </div>
           <div className={styles.exampleContainer}>
             <Example7 />

--- a/demo/src/components/App/components/Example6s/Example6s.js
+++ b/demo/src/components/App/components/Example6s/Example6s.js
@@ -1,0 +1,90 @@
+import theme from '../theme.less';
+
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { updateInputValue, updateFocusedItem } from 'actions/app';
+import Autowhatever from 'Autowhatever';
+import SourceCodeLink from 'SourceCodeLink/SourceCodeLink';
+
+const exampleId = '6s';
+const file = `demo/src/components/App/components/Example${exampleId}/Example${exampleId}.js`;
+
+const items0 = [{
+  text: 'Apple'
+}, {
+  text: 'Banana'
+}, {
+  text: 'Cherry'
+}, {
+  text: 'Grapefruit'
+}, {
+  text: 'Lemon'
+}];
+
+// Make list longer!
+const items = [];
+
+for (let { text } of items0) {
+  for (let w of ['cake', 'pie', 'soup', 'tart']) {
+    items.push({ text: `${text} ${w}` });
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    value: state[exampleId].value,
+    focusedSectionIndex: state[exampleId].focusedSectionIndex,
+    focusedItemIndex: state[exampleId].focusedItemIndex
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onChange: event => {
+      dispatch(updateInputValue(exampleId, event.target.value));
+    },
+    onKeyDown: (event, { newFocusedSectionIndex, newFocusedItemIndex }) => {
+      if (typeof newFocusedItemIndex !== 'undefined') {
+        event.preventDefault();
+        dispatch(updateFocusedItem(exampleId, newFocusedSectionIndex, newFocusedItemIndex));
+      }
+    }
+  };
+}
+
+function renderItem(item) {
+  return (
+    <span>{item.text}</span>
+  );
+}
+
+class Example extends Component {
+  static propTypes = {
+    value: PropTypes.string.isRequired,
+    focusedSectionIndex: PropTypes.number,
+    focusedItemIndex: PropTypes.number,
+
+    onChange: PropTypes.func.isRequired,
+    onKeyDown: PropTypes.func.isRequired
+  };
+
+  render() {
+    const { value, focusedSectionIndex, focusedItemIndex, onChange, onKeyDown } = this.props;
+    const inputProps = { value, onChange, onKeyDown };
+
+    return (
+      <div>
+        <Autowhatever id={exampleId}
+                      items={items}
+                      renderItem={renderItem}
+                      inputProps={inputProps}
+                      focusedSectionIndex={focusedSectionIndex}
+                      focusedItemIndex={focusedItemIndex}
+                      theme={theme} />
+        <SourceCodeLink file={file} />
+      </div>
+    );
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Example);

--- a/demo/src/components/App/components/theme.less
+++ b/demo/src/components/App/components/theme.less
@@ -37,6 +37,9 @@
   border-bottom-left-radius: @border-radius;
   border-bottom-right-radius: @border-radius;
   z-index: 2;
+
+  max-height: 400px;
+  overflow-y: auto;
 }
 
 .item {

--- a/demo/src/components/App/components/theme.less
+++ b/demo/src/components/App/components/theme.less
@@ -1,4 +1,5 @@
 @font-size: 16px;
+@line-height: 1.25;
 @border-color: #aaa;
 @border-radius: 4px;
 
@@ -34,6 +35,7 @@
   border: 1px solid @border-color;
   background-color: #fff;
   font-size: @font-size;
+  line-height: @line-height;
   border-bottom-left-radius: @border-radius;
   border-bottom-right-radius: @border-radius;
   z-index: 2;

--- a/demo/src/components/reducers/app.js
+++ b/demo/src/components/reducers/app.js
@@ -26,6 +26,11 @@ const initialState = {
     focusedSectionIndex: null,
     focusedItemIndex: null
   },
+  '6s': {
+    value: 'Up/Down (Scrolling)',
+    focusedSectionIndex: null,
+    focusedItemIndex: null
+  },
   7: {
     value: 'Multi section - Up/Down/Enter',
     focusedSectionIndex: null,

--- a/demo/src/components/reducers/app.js
+++ b/demo/src/components/reducers/app.js
@@ -29,7 +29,7 @@ const initialState = {
   '6s': {
     value: 'Up/Down (Scrolling)',
     focusedSectionIndex: null,
-    focusedItemIndex: null
+    focusedItemIndex: 11
   },
   7: {
     value: 'Multi section - Up/Down/Enter',

--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -241,7 +241,15 @@ export default class Autowhatever extends Component {
     );
   }
 
+  componentDidMount() {
+    this.ensureFocusedSuggestionIsVisible();
+  }
+
   componentDidUpdate() {
+    this.ensureFocusedSuggestionIsVisible();
+  }
+
+  ensureFocusedSuggestionIsVisible() {
     if (this.refs.focusedItem) {
       const { focusedItem, itemsContainer } = this.refs;
       const itemOffsetRelativeToContainer = (

--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -1,5 +1,4 @@
 import React, { Component, PropTypes } from 'react';
-import { findDOMNode } from 'react-dom';
 import createSectionIterator from 'section-iterator';
 import themeable from 'react-themeable';
 
@@ -104,6 +103,7 @@ export default class Autowhatever extends Component {
       const isFocused = sectionIndex === focusedSectionIndex && itemIndex === focusedItemIndex;
       const itemProps = {
         id: this.getItemId(sectionIndex, itemIndex),
+        ref: isFocused ? 'focusedItem' : null,
         role: 'option',
         ...theme(itemKey, 'item', isFocused && 'itemFocused'),
         ...itemPropsObj,
@@ -112,10 +112,6 @@ export default class Autowhatever extends Component {
         onMouseDown: onMouseDownFn,
         onClick: onClickFn
       };
-
-      if (isFocused) {
-        itemProps.ref = 'focusedItem';
-      }
 
       return (
         <li {...itemProps}>
@@ -247,24 +243,22 @@ export default class Autowhatever extends Component {
 
   componentDidUpdate() {
     if (this.refs.focusedItem) {
-      const itemNode = findDOMNode(this.refs.focusedItem);
-      const containerNode = findDOMNode(this.refs.itemsContainer);
-
+      const { focusedItem, itemsContainer } = this.refs;
       const itemOffsetRelativeToContainer = (
-        itemNode.offsetParent === containerNode
-        ? itemNode.offsetTop
-        : itemNode.offsetTop - containerNode.offsetTop);
-      let scrollTop = containerNode.scrollTop;  // Top of visible area
+        focusedItem.offsetParent === itemsContainer
+        ? focusedItem.offsetTop
+        : focusedItem.offsetTop - itemsContainer.offsetTop);
 
+      let { scrollTop } = itemsContainer;  // Top of visible area
       if (itemOffsetRelativeToContainer < scrollTop) {
         // Item is off the top of visible area. Scroll so it is topmost item.
         scrollTop = itemOffsetRelativeToContainer;
-      } else if (itemOffsetRelativeToContainer + itemNode.offsetHeight > scrollTop + containerNode.offsetHeight) {
+      } else if (itemOffsetRelativeToContainer + focusedItem.offsetHeight > scrollTop + itemsContainer.offsetHeight) {
         // Item is off bottom of visible area. Scroll so it is at bottom.
-        scrollTop = itemOffsetRelativeToContainer + itemNode.offsetHeight - containerNode.offsetHeight;
+        scrollTop = itemOffsetRelativeToContainer + focusedItem.offsetHeight - itemsContainer.offsetHeight;
       }
-      if (scrollTop !== containerNode.scrollTop) {
-        containerNode.scrollTop = scrollTop;
+      if (scrollTop !== itemsContainer.scrollTop) {
+        itemsContainer.scrollTop = scrollTop;
       }
     }
   }


### PR DESCRIPTION
When user is selecting items using the keyboard up and down arrows, the container is scrolled if necessary so the newly focused item will be in the visible part. This only makes a difference when the container has `max-height` and `overflow-y` properties set.

For this to be useful in an autosuggest widget you also need code there ([Pull request #153][1]) to prevent the suggestion scrolled to underneath the mouse cursor from being focused by mistake.

  [1]: https://github.com/moroshko/react-autosuggest/pull/153