### PR TITLE
Add `renderInput` method to customise input element and use `wrap` option from section-iterator

### DIFF
--- a/demo/src/components/App/App.js
+++ b/demo/src/components/App/App.js
@@ -11,6 +11,7 @@ import Example5 from 'Example5/Example5';
 import Example6 from 'Example6/Example6';
 import Example7 from 'Example7/Example7';
 import Example8 from 'Example8/Example8';
+import Example9 from 'Example9/Example9';
 
 export default class App extends Component {
   render() {
@@ -51,6 +52,9 @@ export default class App extends Component {
           </div>
           <div className={styles.exampleContainer}>
             <Example8 />
+          </div>
+          <div className={styles.exampleContainer}>
+            <Example9 />
           </div>
         </div>
         <ForkMeOnGitHub user="moroshko" repo="react-autowhatever" />

--- a/demo/src/components/App/App.js
+++ b/demo/src/components/App/App.js
@@ -12,6 +12,7 @@ import Example6 from 'Example6/Example6';
 import Example7 from 'Example7/Example7';
 import Example8 from 'Example8/Example8';
 import Example9 from 'Example9/Example9';
+import Example10 from 'Example10/Example10';
 
 export default class App extends Component {
   render() {
@@ -55,6 +56,9 @@ export default class App extends Component {
           </div>
           <div className={styles.exampleContainer}>
             <Example9 />
+          </div>
+          <div className={styles.exampleContainer}>
+            <Example10 />
           </div>
         </div>
         <ForkMeOnGitHub user="moroshko" repo="react-autowhatever" />

--- a/demo/src/components/App/components/Example10/Example10.js
+++ b/demo/src/components/App/components/Example10/Example10.js
@@ -1,0 +1,82 @@
+import theme from '../theme.less';
+
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { updateInputValue, updateFocusedItem } from 'actions/app';
+import Autowhatever from 'Autowhatever';
+import SourceCodeLink from 'SourceCodeLink/SourceCodeLink';
+
+const exampleId = '10';
+const file = `demo/src/components/App/components/Example${exampleId}/Example${exampleId}.js`;
+
+const items = [{
+  text: 'Apple'
+}, {
+  text: 'Banana'
+}, {
+  text: 'Cherry'
+}, {
+  text: 'Grapefruit'
+}, {
+  text: 'Lemon'
+}];
+
+function mapStateToProps(state) {
+  return {
+    value: state[exampleId].value,
+    focusedSectionIndex: state[exampleId].focusedSectionIndex,
+    focusedItemIndex: state[exampleId].focusedItemIndex
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onChange: event => {
+      dispatch(updateInputValue(exampleId, event.target.value));
+    },
+    onKeyDown: (event, { newFocusedSectionIndex, newFocusedItemIndex }) => {
+      if (typeof newFocusedItemIndex !== 'undefined') {
+        event.preventDefault();
+        dispatch(updateFocusedItem(exampleId, newFocusedSectionIndex, newFocusedItemIndex));
+      }
+    }
+  };
+}
+
+function renderItem(item) {
+  return (
+    <span>{item.text}</span>
+  );
+}
+
+class Example extends Component {
+  static propTypes = {
+    value: PropTypes.string.isRequired,
+    focusedSectionIndex: PropTypes.number,
+    focusedItemIndex: PropTypes.number,
+
+    onChange: PropTypes.func.isRequired,
+    onKeyDown: PropTypes.func.isRequired
+  };
+
+  render() {
+    const { value, focusedSectionIndex, focusedItemIndex, onChange, onKeyDown } = this.props;
+    const inputProps = { value, onChange, onKeyDown };
+
+    return (
+      <div>
+        <Autowhatever id={exampleId}
+                      items={items}
+                      wrapItemFocus={false}
+                      renderItem={renderItem}
+                      inputProps={inputProps}
+                      focusedSectionIndex={focusedSectionIndex}
+                      focusedItemIndex={focusedItemIndex}
+                      theme={theme} />
+        <SourceCodeLink file={file} />
+      </div>
+    );
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Example);

--- a/demo/src/components/App/components/Example9/Example9.js
+++ b/demo/src/components/App/components/Example9/Example9.js
@@ -1,4 +1,5 @@
 import theme from '../theme.less';
+import css from './customStyles.less';
 
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
@@ -6,47 +7,20 @@ import { updateInputValue, updateFocusedItem } from 'actions/app';
 import Autowhatever from 'Autowhatever';
 import SourceCodeLink from 'SourceCodeLink/SourceCodeLink';
 
-const exampleId = '8';
+const exampleId = '9';
 const file = `demo/src/components/App/components/Example${exampleId}/Example${exampleId}.js`;
 
 const items = [{
-  title: 'A',
-  items: [{
-    text: 'Apple'
-  }, {
-    text: 'Apricot'
-  }]
+  text: 'Apple'
 }, {
-  title: 'B',
-  items: [{
-    text: 'Banana'
-  }]
+  text: 'Banana'
 }, {
-  title: 'C',
-  items: [{
-    text: 'Cherry'
-  }]
+  text: 'Cherry'
+}, {
+  text: 'Grapefruit'
+}, {
+  text: 'Lemon'
 }];
-
-function shouldRenderSection(section) {
-  return section.items.length > 0;
-}
-
-function renderSectionTitle(section) {
-  return (
-    <strong>{section.title}</strong>
-  );
-}
-
-function getSectionItems(section) {
-  return section.items;
-}
-
-function renderItem(item) {
-  return (
-    <span>{item.text}</span>
-  );
-}
 
 function mapStateToProps(state) {
   return {
@@ -61,20 +35,28 @@ function mapDispatchToProps(dispatch) {
     onChange: event => {
       dispatch(updateInputValue(exampleId, event.target.value));
     },
-    onKeyDown: (event, { focusedSectionIndex, focusedItemIndex, newFocusedSectionIndex, newFocusedItemIndex }) => {
-      switch (event.key) {
-        case 'ArrowDown':
-        case 'ArrowUp':
-          event.preventDefault();
-          dispatch(updateFocusedItem(exampleId, newFocusedSectionIndex, newFocusedItemIndex));
-          break;
-
-        case 'Enter':
-          dispatch(updateInputValue(exampleId, items[focusedSectionIndex].items[focusedItemIndex].text + ' selected'));
-          break;
-      }
+    onMouseEnter: (event, { sectionIndex, itemIndex }) => {
+      dispatch(updateFocusedItem(exampleId, sectionIndex, itemIndex));
+    },
+    onMouseLeave: () => {
+      dispatch(updateFocusedItem(exampleId, null, null));
+    },
+    onMouseDown: (event, { itemIndex }) => {
+      dispatch(updateInputValue(exampleId, items[itemIndex].text + ' clicked'));
     }
   };
+}
+
+function renderItem(item) {
+  return (
+    <span>{item.text}</span>
+  );
+}
+
+function renderInput(inputProps) {
+  return (
+    <div {...inputProps} className={`${inputProps.className} ${css.input}`}>{inputProps.value}</div>
+  );
 }
 
 class Example extends Component {
@@ -84,23 +66,32 @@ class Example extends Component {
     focusedItemIndex: PropTypes.number,
 
     onChange: PropTypes.func.isRequired,
-    onKeyDown: PropTypes.func.isRequired
+    onMouseEnter: PropTypes.func.isRequired,
+    onMouseLeave: PropTypes.func.isRequired,
+    onMouseDown: PropTypes.func.isRequired
   };
 
   render() {
-    const { value, focusedSectionIndex, focusedItemIndex, onChange, onKeyDown } = this.props;
-    const inputProps = { value, onChange, onKeyDown };
+    const { value, focusedSectionIndex, focusedItemIndex, onChange,
+            onMouseEnter, onMouseLeave, onMouseDown } = this.props;
+    const inputProps = {
+      value,
+      onChange,
+      tabIndex: 0,
+      autoComplete: null,
+      type: null,
+      ref: null
+    };
+    const itemProps = { onMouseEnter, onMouseLeave, onMouseDown };
 
     return (
       <div>
         <Autowhatever id={exampleId}
-                      multiSection={true}
                       items={items}
-                      shouldRenderSection={shouldRenderSection}
-                      renderSectionTitle={renderSectionTitle}
-                      getSectionItems={getSectionItems}
                       renderItem={renderItem}
+                      renderInput={renderInput}
                       inputProps={inputProps}
+                      itemProps={itemProps}
                       focusedSectionIndex={focusedSectionIndex}
                       focusedItemIndex={focusedItemIndex}
                       theme={theme} />

--- a/demo/src/components/App/components/Example9/customStyles.less
+++ b/demo/src/components/App/components/Example9/customStyles.less
@@ -1,0 +1,11 @@
+.input {
+  width: auto;
+  display: inline-block;
+  line-height: 30px;
+  color: #444;
+  font-weight: bold;
+
+  &:focus {
+    background: #eee;
+  }
+}

--- a/demo/src/components/reducers/app.js
+++ b/demo/src/components/reducers/app.js
@@ -35,6 +35,11 @@ const initialState = {
     value: 'Multi section - Up/Down/Enter',
     focusedSectionIndex: null,
     focusedItemIndex: null
+  },
+  9: {
+    value: 'Custom input element',
+    focusedSectionIndex: null,
+    focusedItemIndex: null
   }
 };
 

--- a/demo/src/components/reducers/app.js
+++ b/demo/src/components/reducers/app.js
@@ -40,6 +40,11 @@ const initialState = {
     value: 'Custom input element',
     focusedSectionIndex: null,
     focusedItemIndex: null
+  },
+  10: {
+    value: 'Don\'t wrap focused suggestion',
+    focusedSectionIndex: null,
+    focusedItemIndex: null
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "react-themeable": "^1.0.1",
-    "section-iterator": "^2.0.0"
+    "section-iterator": "git://github.com/packetloop/section-iterator#dist"
   },
   "peerDependencies": {
     "react": "^0.14.7 || ^15.0.1"

--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -21,6 +21,7 @@ export default class Autowhatever extends Component {
     ]),
     focusedSectionIndex: PropTypes.number, // Section index of the focused item
     focusedItemIndex: PropTypes.number,    // Focused item index (within a section)
+    wrapItemFocus: PropTypes.bool,        // Should using arrow keys to navigate options result in null options
     theme: PropTypes.object                // Styles. See: https://github.com/markdalgleish/react-themeable
   };
 
@@ -42,6 +43,7 @@ export default class Autowhatever extends Component {
     itemProps: {},
     focusedSectionIndex: null,
     focusedItemIndex: null,
+    wrapItemFocus: true,
     theme: {
       container: 'react-autowhatever__container',
       containerOpen: 'react-autowhatever__container--open',
@@ -194,7 +196,7 @@ export default class Autowhatever extends Component {
   }
 
   onKeyDown(event) {
-    const { inputProps, focusedSectionIndex, focusedItemIndex } = this.props;
+    const { inputProps, focusedSectionIndex, focusedItemIndex, wrapItemFocus } = this.props;
     const { onKeyDown: onKeyDownFn } = inputProps; // Babel is throwing:
                                                    //   "onKeyDown" is read-only
                                                    // on:
@@ -206,6 +208,7 @@ export default class Autowhatever extends Component {
         const { multiSection, items, getSectionItems } = this.props;
         const sectionIterator = createSectionIterator({
           multiSection,
+          wrap: wrapItemFocus,
           data: multiSection ?
             items.map(section => getSectionItems(section).length) :
             items.length

--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -10,6 +10,7 @@ export default class Autowhatever extends Component {
     multiSection: PropTypes.bool,          // Indicates whether a multi section layout should be rendered.
     items: PropTypes.array.isRequired,     // Array of items or sections to render.
     renderItem: PropTypes.func,            // This function renders a single item.
+    renderInput: PropTypes.func,           // This function renders the input element
     shouldRenderSection: PropTypes.func,   // This function gets a section and returns whether it should be rendered, or not.
     renderSectionTitle: PropTypes.func,    // This function gets a section and renders its title.
     getSectionItems: PropTypes.func,       // This function gets a section and returns its items, which will be passed into `renderItem` for rendering.
@@ -27,6 +28,7 @@ export default class Autowhatever extends Component {
     id: '1',
     multiSection: false,
     shouldRenderSection: () => true,
+    renderInput: props => <input {...props} />,
     renderItem: () => {
       throw new Error('`renderItem` must be provided');
     },
@@ -248,7 +250,7 @@ export default class Autowhatever extends Component {
   }
 
   render() {
-    const { id, multiSection, focusedSectionIndex, focusedItemIndex } = this.props;
+    const { id, multiSection, focusedSectionIndex, focusedItemIndex, renderInput } = this.props;
     const theme = themeable(this.props.theme);
     const renderedItems = multiSection ? this.renderSections(theme) : this.renderItems(theme);
     const isOpen = (renderedItems !== null);
@@ -267,10 +269,11 @@ export default class Autowhatever extends Component {
       ...this.props.inputProps,
       onKeyDown: this.props.inputProps.onKeyDown && this.onKeyDown
     };
+    const input = renderInput(inputProps);
 
     return (
       <div {...theme(`react-autowhatever-${id}-container`, 'container', isOpen && 'containerOpen')}>
-        <input {...inputProps} />
+        {input}
         {renderedItems}
       </div>
     );


### PR DESCRIPTION
This change adds a `renderInput` method to allow greater control over how the input element is rendered, it still defaults to `<input>`. (Example 8)

Also added a `wrapItemFocus` prop that gets passed through to `section-iterator`. (Example 9) If it is set (default) then the behaviour is unchanged, if it is unset, then:

- When the user presses `Down` when the final item is focused, the final item remains focused
- When the user presses `Up` when the first item is focused, the first item remains focused
