### PR TITLE
Support Tab/Shift-tab to focus item

### DIFF
--- a/demo/src/components/App/components/Example8/Example8.js
+++ b/demo/src/components/App/components/Example8/Example8.js
@@ -65,6 +65,7 @@ function mapDispatchToProps(dispatch) {
       switch (event.key) {
         case 'ArrowDown':
         case 'ArrowUp':
+        case 'Tab':
           event.preventDefault(); // Don't move the cursor to start/end
           dispatch(updateFocusedItem(exampleId, newFocusedSectionIndex, newFocusedItemIndex));
           break;

--- a/demo/src/components/App/redux.js
+++ b/demo/src/components/App/redux.js
@@ -24,17 +24,17 @@ const initialState = {
     focusedItemIndex: null
   },
   6: {
-    value: 'Up/Down',
+    value: 'Up/Down/Tab',
     focusedSectionIndex: null,
     focusedItemIndex: null
   },
   7: {
-    value: 'Up/Down (with scrollbar)',
+    value: 'Up/Down/Tab (with scrollbar)',
     focusedSectionIndex: null,
     focusedItemIndex: 7
   },
   8: {
-    value: 'Multi section - Up/Down/Enter',
+    value: 'Multi section - Up/Down/Tab/Enter',
     focusedSectionIndex: null,
     focusedItemIndex: null
   },

--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -232,6 +232,15 @@ export default class Autowhatever extends Component {
         inputProps.onKeyDown(event, { newFocusedSectionIndex, newFocusedItemIndex });
         break;
       }
+      case 'Tab': {
+        event.preventDefault();
+        const nextPrev = (event.shiftKey ? 'prev' : 'next');
+        const [newFocusedSectionIndex, newFocusedItemIndex] =
+          this.sectionIterator[nextPrev]([focusedSectionIndex, focusedItemIndex]);
+
+        inputProps.onKeyDown(event, { newFocusedSectionIndex, newFocusedItemIndex });
+        break;
+      }
 
       default:
         inputProps.onKeyDown(event, { focusedSectionIndex, focusedItemIndex });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -57,5 +57,11 @@ export const clickUp = () =>
 export const clickDown = () =>
   Simulate.keyDown(input, { key: 'ArrowDown' });
 
+export const tabUp = () =>
+  Simulate.keyDown(input, { key: 'Tab', shiftKey: true });
+
+export const tabDown = () =>
+  Simulate.keyDown(input, { key: 'Tab' });
+
 export const clickEnter = () =>
   Simulate.keyDown(input, { key: 'Enter' });

--- a/test/multi-section/Autowhatever.test.js
+++ b/test/multi-section/Autowhatever.test.js
@@ -7,7 +7,9 @@ import {
   eventMatcher,
   clickUp,
   clickDown,
-  clickEnter
+  clickEnter,
+  tabUp,
+  tabDown
 } from '../helpers';
 import AutowhateverApp, {
   getSectionItems,
@@ -84,6 +86,51 @@ describe('Multi Section Autowhatever', () => {
       expect(onKeyDown).to.be.calledWith(eventMatcher, {
         newFocusedSectionIndex: null,
         newFocusedItemIndex: null
+      });
+    });
+
+    it('should be called with the right parameters when Tab/Shift-tab is pressed', () => {
+      tabDown();
+      expect(onKeyDown).to.be.calledOnce;
+      expect(onKeyDown).to.be.calledWith(eventMatcher, {
+        newFocusedSectionIndex: 0,
+        newFocusedItemIndex: 0
+      });
+
+      tabDown();
+      expect(onKeyDown).to.be.calledWith(eventMatcher, {
+        newFocusedSectionIndex: 0,
+        newFocusedItemIndex: 1
+      });
+
+      tabDown();
+      expect(onKeyDown).to.be.calledWith(eventMatcher, {
+        newFocusedSectionIndex: 1,
+        newFocusedItemIndex: 0
+      });
+
+      tabDown();
+      expect(onKeyDown).to.be.calledWith(eventMatcher, {
+        newFocusedSectionIndex: 2,
+        newFocusedItemIndex: 0
+      });
+
+      tabDown();
+      expect(onKeyDown).to.be.calledWith(eventMatcher, {
+        newFocusedSectionIndex: null,
+        newFocusedItemIndex: null
+      });
+
+      tabUp();
+      expect(onKeyDown).to.be.calledWith(eventMatcher, {
+        newFocusedSectionIndex: 2,
+        newFocusedItemIndex: 0
+      });
+
+      tabUp();
+      expect(onKeyDown).to.be.calledWith(eventMatcher, {
+        newFocusedSectionIndex: 1,
+        newFocusedItemIndex: 0
       });
     });
 

--- a/test/multi-section/AutowhateverApp.js
+++ b/test/multi-section/AutowhateverApp.js
@@ -18,7 +18,7 @@ export const renderItem = sinon.spy(item => (
 ));
 
 export const onKeyDown = sinon.spy((event, { newFocusedSectionIndex, newFocusedItemIndex }) => {
-  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Tab') {
     app.setState({
       focusedSectionIndex: newFocusedSectionIndex,
       focusedItemIndex: newFocusedItemIndex


### PR DESCRIPTION
As ArrowDown/ArrowUp keys, Tab/Shift-Tab keys can be use to navigate through
the list of items and focus one.