### PR TITLE
Fix theming for aphrodite

### DIFF
--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -37,7 +37,10 @@ export default class Autowhatever extends Component {
     ]),
     focusedSectionIndex: PropTypes.number, // Section index of the focused item
     focusedItemIndex: PropTypes.number,    // Focused item index (within a section)
-    theme: PropTypes.object                // Styles. See: https://github.com/markdalgleish/react-themeable
+    theme: PropTypes.oneOfType([           // Styles. See: https://github.com/markdalgleish/react-themeable
+      PropTypes.object,
+      PropTypes.array
+    ]),
   };
 
   static defaultProps = {


### PR DESCRIPTION
Now allows either an object or an array to be passed to the
theme prop. See this https://github.com/markdalgleish/react-themeable#aphrodite
and https://github.com/markdalgleish/react-themeable/blob/master/src/index.js#L6
for more information.