### PR TITLE
Test that ref to input works with custom inputComponent

### DIFF
--- a/test/plain-list/AutowhateverApp.js
+++ b/test/plain-list/AutowhateverApp.js
@@ -55,6 +55,11 @@ export default class AutowhateverApp extends Component {
 
   render() {
     const { value, focusedItemIndex } = this.state;
+    const inputComponent = props => (
+      <div id="my-custom-input-component">
+        <input {...props} type="text" />
+      </div>
+    );
     const inputProps = {
       id: 'my-fancy-input',
       value,
@@ -71,6 +76,7 @@ export default class AutowhateverApp extends Component {
         id="my-fancy-component"
         items={items}
         renderItem={renderItem}
+        inputComponent={inputComponent}
         inputProps={inputProps}
         itemProps={itemProps}
         focusedItemIndex={focusedItemIndex}


### PR DESCRIPTION
As noted in https://github.com/moroshko/react-autosuggest/issues/269, the `input` property is undefined on `ref` callbacks. The underlying problem seems to be here in react-autowhatever, and while I don't know how to fix it (because I still don't understand exactly why it is happening) this pull request modifies the test case to demonstrate the problem.

Maybe because `ref` is not a real property and hence doesn't get passed to the custom `inputComponent` along with the other props?
