### PR TITLE
Add isHighlighted flag as data to renderItem

### DIFF
--- a/src/Item.js
+++ b/src/Item.js
@@ -5,6 +5,7 @@ import compareObjects from './compareObjects';
 export default class Item extends Component {
   static propTypes = {
     sectionIndex: PropTypes.number,
+    isHighlighted: PropTypes.bool.isRequired,
     itemIndex: PropTypes.number.isRequired,
     item: PropTypes.any.isRequired,
     renderItem: PropTypes.func.isRequired,
@@ -50,7 +51,7 @@ export default class Item extends Component {
   };
 
   render() {
-    const { item, renderItem, renderItemData, ...restProps } = this.props;
+    const { isHighlighted, item, renderItem, renderItemData, ...restProps } = this.props;
 
     delete restProps.sectionIndex;
     delete restProps.itemIndex;
@@ -73,7 +74,7 @@ export default class Item extends Component {
 
     return (
       <li role="option" {...restProps} ref={this.storeItemReference}>
-        {renderItem(item, renderItemData)}
+        {renderItem(item, { isHighlighted, ...renderItemData })}
       </li>
     );
   }

--- a/src/ItemsList.js
+++ b/src/ItemsList.js
@@ -64,6 +64,7 @@ export default class ItemsList extends Component {
               <Item
                 {...allItemProps}
                 sectionIndex={sectionIndex}
+                isHighlighted={isHighlighted}
                 itemIndex={itemIndex}
                 item={item}
                 renderItem={renderItem}

--- a/test/plain-list/Autowhatever.test.js
+++ b/test/plain-list/Autowhatever.test.js
@@ -66,6 +66,18 @@ describe('Plain List Autowhatever', () => {
       expect(renderItem).to.have.been.calledTwice;
     });
 
+    it('should call `renderItem` with `isHighlighted` flag', () => {
+      renderItem.reset();
+      mouseEnterItem(0);
+      expect(renderItem).to.have.been.calledOnce;
+      expect(renderItem).to.be.calledWith({ text: 'Apple' }, { isHighlighted: true });
+
+      renderItem.reset();
+      mouseLeaveItem(0);
+      expect(renderItem).to.have.been.calledOnce;
+      expect(renderItem).to.be.calledWith({ text: 'Apple' }, { isHighlighted: false });
+    });
+
     it('should call `renderItem` once when item is left', () => {
       mouseEnterItem(3);
       renderItem.reset();


### PR DESCRIPTION
These changes are to add an `isHighlighted` flag to the render data for `renderItem`. This will make it easier to style highlighted items differently, as mentioned in https://github.com/moroshko/react-autosuggest/issues/383