### PR TITLE
Allow custom list item rendering by exposing a render function for it

### DIFF
--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -9,6 +9,8 @@ const emptyObject = {};
 const defaultRenderInputComponent = props => <input {...props} />;
 const defaultRenderItemsContainer =
   ({ containerProps, children }) => <div {...containerProps}>{children}</div>;
+const defaultRenderListItemContainer =
+  ({ containerProps,children }) => <li role="option" {...containerProps}>{children}</li>;
 const defaultTheme = {
   container: 'react-autowhatever__container',
   containerOpen: 'react-autowhatever__container--open',
@@ -28,17 +30,18 @@ const defaultTheme = {
 
 export default class Autowhatever extends Component {
   static propTypes = {
-    id: PropTypes.string,                 // Used in aria-* attributes. If multiple Autowhatever's are rendered on a page, they must have unique ids.
-    multiSection: PropTypes.bool,         // Indicates whether a multi section layout should be rendered.
-    renderInputComponent: PropTypes.func, // When specified, it is used to render the input element.
-    renderItemsContainer: PropTypes.func, // Renders the items container.
-    items: PropTypes.array.isRequired,    // Array of items or sections to render.
-    renderItem: PropTypes.func,           // This function renders a single item.
-    renderItemData: PropTypes.object,     // Arbitrary data that will be passed to renderItem()
-    renderSectionTitle: PropTypes.func,   // This function gets a section and renders its title.
-    getSectionItems: PropTypes.func,      // This function gets a section and returns its items, which will be passed into `renderItem` for rendering.
-    inputProps: PropTypes.object,         // Arbitrary input props
-    itemProps: PropTypes.oneOfType([      // Arbitrary item props
+    id: PropTypes.string,                    // Used in aria-* attributes. If multiple Autowhatever's are rendered on a page, they must have unique ids.
+    multiSection: PropTypes.bool,            // Indicates whether a multi section layout should be rendered.
+    renderInputComponent: PropTypes.func,    // When specified, it is used to render the input element.
+    renderItemsContainer: PropTypes.func,    // Renders the items container.
+    renderListItemContainer: PropTypes.func, // Renders the list item container.
+    items: PropTypes.array.isRequired,       // Array of items or sections to render.
+    renderItem: PropTypes.func,              // This function renders a single item.
+    renderItemData: PropTypes.object,        // Arbitrary data that will be passed to renderItem()
+    renderSectionTitle: PropTypes.func,      // This function gets a section and renders its title.
+    getSectionItems: PropTypes.func,         // This function gets a section and returns its items, which will be passed into `renderItem` for rendering.
+    inputProps: PropTypes.object,            // Arbitrary input props
+    itemProps: PropTypes.oneOfType([         // Arbitrary item props
       PropTypes.object,
       PropTypes.func
     ]),
@@ -55,6 +58,7 @@ export default class Autowhatever extends Component {
     multiSection: false,
     renderInputComponent: defaultRenderInputComponent,
     renderItemsContainer: defaultRenderItemsContainer,
+    renderListItemContainer: defaultRenderListItemContainer,
     renderItem: () => {
       throw new Error('`renderItem` must be provided');
     },
@@ -161,7 +165,7 @@ export default class Autowhatever extends Component {
 
     const { theme } = this;
     const {
-      id, items, renderItem, renderItemData, renderSectionTitle,
+      id, items,renderListItemContainer, renderItem, renderItemData, renderSectionTitle,
       highlightedSectionIndex, highlightedItemIndex, itemProps
     } = this.props;
 
@@ -185,6 +189,7 @@ export default class Autowhatever extends Component {
             itemProps={itemProps}
             renderItem={renderItem}
             renderItemData={renderItemData}
+            renderListItemContainer={renderListItemContainer}
             sectionIndex={sectionIndex}
             highlightedItemIndex={highlightedSectionIndex === sectionIndex ? highlightedItemIndex : null}
             onHighlightedItemChange={this.onHighlightedItemChange}
@@ -208,7 +213,7 @@ export default class Autowhatever extends Component {
 
     const { theme } = this;
     const {
-      id, renderItem, renderItemData, highlightedSectionIndex,
+      id, renderListItemContainer, renderItem, renderItemData, highlightedSectionIndex,
       highlightedItemIndex, itemProps
     } = this.props;
 
@@ -216,6 +221,7 @@ export default class Autowhatever extends Component {
       <ItemsList
         items={items}
         itemProps={itemProps}
+        renderListItemContainer={renderListItemContainer}
         renderItem={renderItem}
         renderItemData={renderItemData}
         highlightedItemIndex={highlightedSectionIndex === null ? highlightedItemIndex : null}

--- a/src/Item.js
+++ b/src/Item.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import { Component } from 'react';
 import PropTypes from 'prop-types';
 import compareObjects from './compareObjects';
 
@@ -10,6 +10,7 @@ export default class Item extends Component {
     item: PropTypes.any.isRequired,
     renderItem: PropTypes.func.isRequired,
     renderItemData: PropTypes.object.isRequired,
+    renderListItemContainer: PropTypes.func.isRequired,
     onMouseEnter: PropTypes.func,
     onMouseLeave: PropTypes.func,
     onMouseDown: PropTypes.func,
@@ -51,7 +52,7 @@ export default class Item extends Component {
   };
 
   render() {
-    const { isHighlighted, item, renderItem, renderItemData, ...restProps } = this.props;
+    const { isHighlighted, item, renderItem, renderItemData, renderListItemContainer, ...restProps } = this.props;
 
     delete restProps.sectionIndex;
     delete restProps.itemIndex;
@@ -72,10 +73,12 @@ export default class Item extends Component {
       restProps.onClick = this.onClick;
     }
 
-    return (
-      <li role="option" {...restProps} ref={this.storeItemReference}>
-        {renderItem(item, { isHighlighted, ...renderItemData })}
-      </li>
-    );
+    restProps.ref = this.storeItemReference;
+
+    return renderListItemContainer({
+      item: item,
+      containerProps: restProps,
+      children: renderItem(item, { isHighlighted, ...renderItemData })
+    });
   }
 }

--- a/src/ItemsList.js
+++ b/src/ItemsList.js
@@ -10,6 +10,7 @@ export default class ItemsList extends Component {
       PropTypes.object,
       PropTypes.func
     ]),
+    renderListItemContainer: PropTypes.func.isRequired,
     renderItem: PropTypes.func.isRequired,
     renderItemData: PropTypes.object.isRequired,
     sectionIndex: PropTypes.number,
@@ -34,7 +35,7 @@ export default class ItemsList extends Component {
 
   render() {
     const {
-      items, itemProps, renderItem, renderItemData, sectionIndex,
+      items, itemProps, renderListItemContainer, renderItem, renderItemData, sectionIndex,
       highlightedItemIndex, getItemId, theme, keyPrefix
     } = this.props;
     const sectionPrefix = (sectionIndex === null ? keyPrefix : `${keyPrefix}section-${sectionIndex}-`);
@@ -67,6 +68,7 @@ export default class ItemsList extends Component {
                 isHighlighted={isHighlighted}
                 itemIndex={itemIndex}
                 item={item}
+                renderListItemContainer={renderListItemContainer}
                 renderItem={renderItem}
                 renderItemData={renderItemData}
               />

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -22,6 +22,12 @@ export const containerPropsMatcher = sinon.match({
   className: sinon.match.string,
   ref: sinon.match.func
 });
+export const listItemContainerPropsMatcher = sinon.match({
+  id: sinon.match.string,
+  className: sinon.match.string,
+  ref: sinon.match.func
+});
+export const itemMatcher = sinon.match.any;
 
 export const getElementWithClass =
   className => TestUtils.findRenderedDOMComponentWithClass(app, className);

--- a/test/render-list-item-container/Autowhatever.test.js
+++ b/test/render-list-item-container/Autowhatever.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { expect } from 'chai';
+import {
+  init,
+  childrenMatcher,
+  listItemContainerPropsMatcher,
+  itemMatcher,
+  getElementWithClass
+} from '../helpers';
+import AutowhateverApp, {
+  renderListItemContainer
+} from './AutowhateverApp';
+
+describe('Autowhatever with renderListItemContainer', () => {
+  beforeEach(() => {
+    renderListItemContainer.reset();
+    init(TestUtils.renderIntoDocument(<AutowhateverApp />));
+  });
+
+  it('should render whatever renderListItemContainer returns', () => {
+    expect(getElementWithClass('Apple-list-item-container-class')).not.to.equal(null);
+  });
+
+  it('should call renderListItemContainer once with the right parameters', () => {
+    expect(renderListItemContainer).to.have.been.calledOnce;
+    expect(renderListItemContainer).to.be.calledWith({
+      item: itemMatcher,
+      children: childrenMatcher,
+      containerProps: listItemContainerPropsMatcher
+    });
+  });
+});

--- a/test/render-list-item-container/AutowhateverApp.js
+++ b/test/render-list-item-container/AutowhateverApp.js
@@ -1,0 +1,47 @@
+import React, { Component } from 'react';
+import sinon from 'sinon';
+import Autowhatever from '../../src/Autowhatever';
+import items from './items';
+
+export const renderItem = item => item.text;
+
+export const renderListItemContainer = sinon.spy(({ item, containerProps, children }) => (
+  <li {...containerProps} className={item.text + '-list-item-container-class'}>
+    {children}
+  </li>
+));
+
+export default class AutowhateverApp extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      value: ''
+    };
+  }
+
+  onChange = event => {
+    this.setState({
+      value: event.target.value
+    });
+  };
+
+  render() {
+    const { value } = this.state;
+    const inputProps = {
+      id: 'my-custom-input',
+      value,
+      onChange: this.onChange
+    };
+
+    return (
+      <Autowhatever
+        id="my-id"
+        renderListItemContainer={renderListItemContainer}
+        items={items}
+        renderItem={renderItem}
+        inputProps={inputProps}
+      />
+    );
+  }
+}

--- a/test/render-list-item-container/items.js
+++ b/test/render-list-item-container/items.js
@@ -1,0 +1,5 @@
+export default [
+  {
+    text: 'Apple'
+  }
+];


### PR DESCRIPTION
Hey @moroshko thanks for this library I've found it to be super useful.

These changes expose a renderListItemContainer function so that one could override how the `<li>` elements are currently being rendered.

I needed this while building out a component and needed different DOM structures based on the element in the list. I know I could use renderItem, but I needed to modify the parent as well.

Hope this makes sense, LMK what else I can do.