### PR TITLE
Don't default isOpen to false if using renderItemsContainer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 demo/dist
 npm-debug.log
 yarn.lock
+.idea/

--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -302,7 +302,10 @@ export default class Autowhatever extends Component {
     } = this.props;
     const { isInputFocused } = this.state;
     const renderedItems = multiSection ? this.renderSections() : this.renderItems();
-    const isOpen = (renderedItems !== null);
+    const isOpen = (
+      renderedItems !== null ||
+      renderItemsContainer !== defaultRenderItemsContainer
+    );
     const ariaActivedescendant = this.getItemId(highlightedSectionIndex, highlightedItemIndex);
     const containerProps = theme(
       `react-autowhatever-${id}-container`,

--- a/test/render-empty-items-with-items-container/Autowhatever.test.js
+++ b/test/render-empty-items-with-items-container/Autowhatever.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { expect } from 'chai';
+import {
+  init,
+  getInputAttribute
+} from '../helpers';
+import AutowhateverApp, {
+  renderItemsContainer
+} from './AutowhateverApp';
+
+describe('Autowhatever with empty items and renderItemsContainer', () => {
+  beforeEach(() => {
+    renderItemsContainer.reset();
+    init(TestUtils.renderIntoDocument(<AutowhateverApp />));
+  });
+
+  it('should be open since this is rendered with a custom container', () => {
+    expect(getInputAttribute('aria-expanded')).to.equal('true');
+  });
+});

--- a/test/render-empty-items-with-items-container/AutowhateverApp.js
+++ b/test/render-empty-items-with-items-container/AutowhateverApp.js
@@ -1,0 +1,50 @@
+import React, { Component } from 'react';
+import sinon from 'sinon';
+import Autowhatever from '../../src/Autowhatever';
+import items from './items';
+
+export const renderItem = item => item.text;
+
+export const renderItemsContainer = sinon.spy(({ containerProps, children }) => (
+  <div {...containerProps}>
+    {children}
+    <div className="my-items-container-footer">
+      Footer
+    </div>
+  </div>
+));
+
+export default class AutowhateverApp extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      value: ''
+    };
+  }
+
+  onChange = event => {
+    this.setState({
+      value: event.target.value
+    });
+  };
+
+  render() {
+    const { value } = this.state;
+    const inputProps = {
+      id: 'my-custom-input',
+      value,
+      onChange: this.onChange
+    };
+
+    return (
+      <Autowhatever
+        id="my-id"
+        renderItemsContainer={renderItemsContainer}
+        items={items}
+        renderItem={renderItem}
+        inputProps={inputProps}
+      />
+    );
+  }
+}

--- a/test/render-empty-items-with-items-container/items.js
+++ b/test/render-empty-items-with-items-container/items.js
@@ -1,0 +1,1 @@
+export default [];

--- a/test/render-empty-items/Autowhatever.test.js
+++ b/test/render-empty-items/Autowhatever.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import TestUtils from 'react-dom/test-utils';
+import { expect } from 'chai';
+import {
+  init,
+  getInputAttribute
+} from '../helpers';
+import AutowhateverApp from './AutowhateverApp';
+
+describe('Autowhatever with empty items and default items container', () => {
+  beforeEach(() => {
+    init(TestUtils.renderIntoDocument(<AutowhateverApp />));
+  });
+
+  it('should be closed since this is rendered without a custom container', () => {
+    expect(getInputAttribute('aria-expanded')).to.equal('false');
+  });
+});

--- a/test/render-empty-items/AutowhateverApp.js
+++ b/test/render-empty-items/AutowhateverApp.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react';
+import Autowhatever from '../../src/Autowhatever';
+import items from './items';
+
+export const renderItem = item => item.text;
+
+export default class AutowhateverApp extends Component {
+  constructor() {
+    super();
+
+    this.state = {
+      value: ''
+    };
+  }
+
+  onChange = event => {
+    this.setState({
+      value: event.target.value
+    });
+  };
+
+  render() {
+    const { value } = this.state;
+    const inputProps = {
+      id: 'my-custom-input',
+      value,
+      onChange: this.onChange
+    };
+
+    return (
+      <Autowhatever
+        id="my-id"
+        items={items}
+        renderItem={renderItem}
+        inputProps={inputProps}
+      />
+    );
+  }
+}

--- a/test/render-empty-items/items.js
+++ b/test/render-empty-items/items.js
@@ -1,0 +1,1 @@
+export default [];


### PR DESCRIPTION
This PR addresses an issue brought up by this issue in react-autosuggest: https://github.com/moroshko/react-autosuggest/issues/486

If a `renderItemsContainer` is provided, `isOpen` is true.  We may want the items container to be open even if there are no `renderedItems`.

I literally used the code change that @moroshko suggested, and added the requisite tests.