### PR TITLE
Improve accessibility on OSX

### DIFF
--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -304,20 +304,24 @@ export default class Autowhatever extends Component {
     const renderedItems = multiSection ? this.renderSections() : this.renderItems();
     const isOpen = (renderedItems !== null);
     const ariaActivedescendant = this.getItemId(highlightedSectionIndex, highlightedItemIndex);
-    const containerProps = theme(
-      `react-autowhatever-${id}-container`,
-      'container',
-      isOpen && 'containerOpen'
-    );
     const itemsContainerId = `react-autowhatever-${id}`;
+    const containerProps = {
+      role: 'combobox',
+      'aria-haspopup': 'listbox',
+      'aria-owns': itemsContainerId,
+      'aria-expanded': isOpen,
+      ...theme(
+        `react-autowhatever-${id}-container`,
+        'container',
+        isOpen && 'containerOpen'
+      )
+    };
     const inputComponent = renderInputComponent({
       type: 'text',
       value: '',
       autoComplete: 'off',
-      role: 'combobox',
       'aria-autocomplete': 'list',
-      'aria-owns': itemsContainerId,
-      'aria-expanded': isOpen,
+      'aria-controls': itemsContainerId,
       'aria-activedescendant': ariaActivedescendant,
       ...theme(
         `react-autowhatever-${id}-input`,
@@ -334,6 +338,7 @@ export default class Autowhatever extends Component {
     const itemsContainer = renderItemsContainer({
       containerProps: {
         id: itemsContainerId,
+        role: 'listbox',
         ...theme(
           `react-autowhatever-${id}-items-container`,
           'itemsContainer',

--- a/src/ItemsList.js
+++ b/src/ItemsList.js
@@ -50,6 +50,7 @@ export default class ItemsList extends Component {
             const itemPropsObj = isItemPropsFunction ? itemProps({ sectionIndex, itemIndex }) : itemProps;
             const allItemProps = {
               id: getItemId(sectionIndex, itemIndex),
+              'aria-selected': isHighlighted,
               ...theme(itemKey, 'item', isFirst && 'itemFirst', isHighlighted && 'itemHighlighted'),
               ...itemPropsObj
             };

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,10 +6,11 @@ import TestUtils, { Simulate } from 'react-dom/test-utils';
 
 chai.use(sinonChai);
 
-let app, input, itemsContainer;
+let app, container, input, itemsContainer;
 
 export const init = application => {
   app = application;
+  container = TestUtils.findRenderedDOMComponentWithClass(app, 'react-autowhatever__container');
   input = TestUtils.findRenderedDOMComponentWithTag(app, 'input');
   itemsContainer = TestUtils.findRenderedDOMComponentWithClass(app, 'react-autowhatever__items-container');
 };
@@ -28,6 +29,9 @@ export const getElementWithClass =
 export const getStoredInput = () => app.autowhatever.input;
 export const getStoredItemsContainer = () => app.autowhatever.itemsContainer;
 export const getStoredHighlightedItem = () => app.autowhatever.highlightedItem;
+
+export const getContainerAttribute = attr =>
+  container.getAttribute(attr);
 
 export const getInputAttribute = attr =>
   input.getAttribute(attr);

--- a/test/plain-list/Autowhatever.test.js
+++ b/test/plain-list/Autowhatever.test.js
@@ -6,9 +6,11 @@ import {
   getStoredInput,
   getStoredItemsContainer,
   getStoredHighlightedItem,
+  getContainerAttribute,
   getInputAttribute,
   getItemsContainerAttribute,
   getItems,
+  getItem,
   mouseEnterItem,
   mouseLeaveItem,
   mouseDownItem,
@@ -25,8 +27,12 @@ describe('Plain List Autowhatever', () => {
   });
 
   describe('initially', () => {
-    it('should set input\'s `aria-owns` to items container\'s `id`', () => {
-      expect(getInputAttribute('aria-owns')).to.equal(getItemsContainerAttribute('id'));
+    it('should set container\'s `aria-owns` to items container\'s `id`', () => {
+      expect(getContainerAttribute('aria-owns')).to.equal(getItemsContainerAttribute('id'));
+    });
+
+    it('should set input\'s `aria-controls` to items container\'s `id`', () => {
+      expect(getInputAttribute('aria-controls')).to.equal(getItemsContainerAttribute('id'));
     });
 
     it('should render all items', () => {
@@ -76,6 +82,16 @@ describe('Plain List Autowhatever', () => {
       mouseLeaveItem(0);
       expect(renderItem).to.have.been.calledOnce;
       expect(renderItem).to.be.calledWith({ text: 'Apple' }, { isHighlighted: false });
+    });
+
+    it('should set `aria-selected` to true on highlighted items', () => {
+      renderItem.reset();
+      mouseEnterItem(0);
+      expect(getItem(0).getAttribute('aria-selected')).to.equal('true');
+
+      renderItem.reset();
+      mouseLeaveItem(0);
+      expect(getItem(0).getAttribute('aria-selected')).to.equal('false');
     });
 
     it('should call `renderItem` once when item is left', () => {


### PR DESCRIPTION
Hello!

This PR aims to fix the voice over bugs on OSX. These issues are open on the React Autosuggest project: moroshko/react-autosuggest#525 and moroshko/react-autosuggest#527.

 I could only make the voice over make sense when following [ARIA 1.1 specifications](https://w3c.github.io/aria-practices/#combobox) for "List autocomplete with automatic selection"

To follow this pattern, I moved the following attributes from the input itself to the wrapper container:
- `role="combobox"`
- `aria-owns`
- `aria-haspopup`
- `aria-expanded`

I also added an `aria-controls` attribute to the input field, `role="listbox"` on the items container and `aria-selected` to the currently highlighted item, which also fixes #31 in the process.

If this PR gets accepted, it will break tests on React Autosuggest which tests for these roles as well. I can make a PR to update those tests once I know if this will get merged.
