### PR TITLE
Add containerProps property for arbitrary props on the container

### DIFF
--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -37,6 +37,7 @@ export default class Autowhatever extends Component {
     renderItemData: PropTypes.object,     // Arbitrary data that will be passed to renderItem()
     renderSectionTitle: PropTypes.func,   // This function gets a section and renders its title.
     getSectionItems: PropTypes.func,      // This function gets a section and returns its items, which will be passed into `renderItem` for rendering.
+    containerProps: PropTypes.object,     // Arbitrary container props
     inputProps: PropTypes.object,         // Arbitrary input props
     itemProps: PropTypes.oneOfType([      // Arbitrary item props
       PropTypes.object,
@@ -65,6 +66,7 @@ export default class Autowhatever extends Component {
     getSectionItems: () => {
       throw new Error('`getSectionItems` must be provided');
     },
+    containerProps: emptyObject,
     inputProps: emptyObject,
     itemProps: emptyObject,
     highlightedSectionIndex: null,
@@ -314,7 +316,8 @@ export default class Autowhatever extends Component {
         `react-autowhatever-${id}-container`,
         'container',
         isOpen && 'containerOpen'
-      )
+      ),
+      ...this.props.containerProps
     };
     const inputComponent = renderInputComponent({
       type: 'text',


### PR DESCRIPTION
This PR adds a new property called `containerProps` to allow customization of props passed to the surrounding `div`.

The main purpose of this is to allow the override of the different `aria-*` and `role` props of the container. In our case, we want to change the `role` of the container to be a `button`, because we override the rendering of the input to be read only so that our behaviour behaves like a `<select>`.
According to  the [w3 example](https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html), in our case we should have a button to open / close our component. As we use `react-autowhatever` it's not a button but a div, but we can simulate that behaviour for assistive technologies by adding `role="button"`.

To follow the convention, we also allow all arbitrary props as it's the case for the input and the item.

Thanks!