### PR TITLE
Let user pass his own ref to input

### DIFF
--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -133,6 +133,15 @@ export default class Autowhatever extends Component {
     if (input !== null) {
       this.input = input;
     }
+
+    const userRef = this.props.inputProps.ref;
+    if (userRef) {
+      if (typeof userRef === 'function') {
+        userRef(input);
+      } else if (typeof userRef === 'object' && userRef.hasOwnProperty('current')) {
+        userRef.current = input;
+      }
+    }
   };
 
   storeItemsContainerReference = itemsContainer => {


### PR DESCRIPTION
In this pull request I added an ability for a user of the library to get its own reference the the input rendered by `react-autowhatever`. In my particular case I need it because I want to control caret position in the native input. I found out that it's not possible in current version of the library, and don't see any reasons to not include this ability.