### PR TITLE
Add aria-labels

### DIFF
--- a/src/Autowhatever.js
+++ b/src/Autowhatever.js
@@ -39,6 +39,7 @@ export default class Autowhatever extends Component {
     getSectionItems: PropTypes.func,      // This function gets a section and returns its items, which will be passed into `renderItem` for rendering.
     containerProps: PropTypes.object,     // Arbitrary container props
     inputProps: PropTypes.object,         // Arbitrary input props
+    ariaLabel: PropTypes.string,          // Sets aria-label
     itemProps: PropTypes.oneOfType([      // Arbitrary item props
       PropTypes.object,
       PropTypes.func
@@ -71,6 +72,7 @@ export default class Autowhatever extends Component {
     itemProps: emptyObject,
     highlightedSectionIndex: null,
     highlightedItemIndex: null,
+    ariaLabel: 'search',
     theme: defaultTheme
   };
 
@@ -300,7 +302,7 @@ export default class Autowhatever extends Component {
     const { theme } = this;
     const {
       id, multiSection, renderInputComponent, renderItemsContainer,
-      highlightedSectionIndex, highlightedItemIndex
+      highlightedSectionIndex, highlightedItemIndex, ariaLabel
     } = this.props;
     const { isInputFocused } = this.state;
     const renderedItems = multiSection ? this.renderSections() : this.renderItems();
@@ -312,6 +314,7 @@ export default class Autowhatever extends Component {
       'aria-haspopup': 'listbox',
       'aria-owns': itemsContainerId,
       'aria-expanded': isOpen,
+      'aria-label': ariaLabel,
       ...theme(
         `react-autowhatever-${id}-container`,
         'container',
@@ -325,6 +328,7 @@ export default class Autowhatever extends Component {
       autoComplete: 'off',
       'aria-autocomplete': 'list',
       'aria-controls': itemsContainerId,
+      'aria-label' : 'suggestions',
       'aria-activedescendant': ariaActivedescendant,
       ...theme(
         `react-autowhatever-${id}-input`,


### PR DESCRIPTION
This pull request is related to [645](https://github.com/moroshko/react-autosuggest/pull/645) When I ran accessibility test on AutoSuggest I received issues that the combobox and input fields don't have descriptions. To fix these issues I added aria-labels which are optional and the users can pass the values of it through props. This would also fix (#485  ), (#283 ),  (#642 ). Aria labels will pe passed down from [react-autosuggest](https://github.com/moroshko/react-autosuggest).
